### PR TITLE
撮影時間を2秒に設定した

### DIFF
--- a/lib/ruboty/handlers/witness.rb
+++ b/lib/ruboty/handlers/witness.rb
@@ -38,7 +38,7 @@ module Ruboty
 
       def still(message)
         image = Tempfile.new(%w(witness .jpg))
-        `raspistill -w 1024 -h 768 -q 50 -o #{image.path}`
+        `raspistill -t 2 -w 1024 -h 768 -q 50 -o #{image.path}`
 
         Thread.new(image) do |img|
           url = upload_s3(img.path)


### PR DESCRIPTION
デフォルトだと5秒掛かってしまって長いのでカメラモジュールの初期化が終わるであろう2秒程度に設定してみた
